### PR TITLE
Bugfix: HMC5883 module

### DIFF
--- a/devices/HMC5883.js
+++ b/devices/HMC5883.js
@@ -26,7 +26,7 @@ exports.connect = function(i2c,drdy,mode) {
 
 function HMC5883(i2c,drdy,mode) {
   this.i2c = i2c;
-  this.mode = (mode) ? mode : 1;
+  this.mode = (typeof mode !== 'undefined') ? mode : 1;
   this.drdy = drdy;
   this.a=0x1E;
   pinMode(drdy,'input');

--- a/devices/HMC5883.js
+++ b/devices/HMC5883.js
@@ -70,7 +70,6 @@ HMC5883.prototype.setGain = function(gain) {
 	this.i2c.writeTo(this.a,1);
     	this.ngain=(this.i2c.readFrom(this.a,1))>>5;
     	if (this.mode!=2) {
-		this.onwatch=c;
 		var hmc=this;
 		setWatch(function(){hmc.readc();},this.drdy);
 		this.setmode(1);

--- a/devices/HMC5883.js
+++ b/devices/HMC5883.js
@@ -69,10 +69,9 @@ HMC5883.prototype.setGain = function(gain) {
 	this.i2c.writeTo(this.a,[1,((gain & 7)<<5)]);
 	this.i2c.writeTo(this.a,1);
     	this.ngain=(this.i2c.readFrom(this.a,1))>>5;
-    	if (this.mode!=2) {
+    	if (this.mode === 1) {
 		var hmc=this;
 		setWatch(function(){hmc.readc();},this.drdy);
-		this.setMode(1);
     	}
 }
 

--- a/devices/HMC5883.js
+++ b/devices/HMC5883.js
@@ -21,7 +21,7 @@ console.log(compass.readc());
 
 
 exports.connect = function(i2c,drdy,mode) {
-    return new HMC5883(i2c,drdy,range);
+    return new HMC5883(i2c,drdy,mode);
 }
 
 function HMC5883(i2c,drdy,mode) {

--- a/devices/HMC5883.js
+++ b/devices/HMC5883.js
@@ -13,7 +13,7 @@ read in single measurement mode:
 compass.reads(function(a){print(a);});
 
 read in continuous measurement mode:
-compass.setmode(0);
+compass.setMode(0);
 console.log(compass.readc());
 
 */
@@ -72,7 +72,7 @@ HMC5883.prototype.setGain = function(gain) {
     	if (this.mode!=2) {
 		var hmc=this;
 		setWatch(function(){hmc.readc();},this.drdy);
-		this.setmode(1);
+		this.setMode(1);
     	}
 }
 
@@ -80,5 +80,5 @@ HMC5883.prototype.reads = function(c) {
 	this.onwatch=c;
 	var hmc=this;
 	setWatch(function(){hmc.onwatch(hmc.readc());},this.drdy);
-	this.setmode(1);
+	this.setMode(1);
 }


### PR DESCRIPTION
The wrong variable was being used in the `connect` function of the `HMC5883` module, causing the module to error at that point.

`git blame` shows just one commit for this file, so I guess this was copy-pasted from some other module and someone forgot to change this.
